### PR TITLE
PrivacyInfo.xcprivacyが取り込まれるようにした

### DIFF
--- a/MBProgressHUD.podspec
+++ b/MBProgressHUD.podspec
@@ -11,10 +11,11 @@ Pod::Spec.new do |s|
   s.homepage     = "http://www.bukovinski.com"
   s.license      = { :type => 'MIT', :file => 'LICENSE' }
   s.author       = { 'Matej Bukovinski' => 'matej@bukovinski.com' }
-  s.source       = { :git => "https://github.com/matej/MBProgressHUD.git", :tag => s.version.to_s }
+  s.source       = { :git => "https://github.com/StudistCorporation/MBProgressHUD.git", :tag => s.version.to_s }
   s.ios.deployment_target = '9.0'
   s.tvos.deployment_target = '9.0'
   s.source_files = '*.{h,m}'
   s.frameworks   = "CoreGraphics", "QuartzCore"
   s.requires_arc = true
+  s.resource_bundles = {'MBProgressHUD' => ['PrivacyInfo.xcprivacy']}
 end

--- a/Package.swift
+++ b/Package.swift
@@ -13,6 +13,7 @@ let package = Package(
             path: ".",
             exclude: ["Demo"],
             sources: ["MBProgressHUD.h", "MBProgressHUD.m"],
+            resources: [.copy("PrivacyInfo.xcprivacy")],
             publicHeadersPath: "include"
         )
     ]


### PR DESCRIPTION
現状のままだとCocoapods経由でインストールしたときPrivacyInfo.xcprivacyがプロジェクトに追加されないので、設定追加する。

Cocoapods経由でインストールして確認済み。
※一応Package.swiftにも設定追加しているが、特に確認はしていない。